### PR TITLE
Access the real C3 API from native builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ dart pub global activate ffigen
 flutter run -d linux|chrome|macos
 ```
 
+To access C3 API dependent functionality in the app, you need to provide environment variables `C3_API_KEY` and `C3_API_USERNAME`:
+
+```bash
+flutter run -d linux --dart-define=C3_API_KEY=ddb2a45ab96fef2836b136b902ff5e651882039e --dart-define=C3_API_USERNAME=mz2 --verbose
+```
+
 There are some tests in the `device-tree-lib` folder which are runnable from over there with `flutter test`.
 
 For VS Code users, launch configurations exist for the application (`.vscode/launch.json`).


### PR DESCRIPTION
Removes some faking that was in place until now from in front of accessing the real C3 API, in the native builds.

API access from web builds continue to be faked until https://warthogs.atlassian.net/browse/C3-120 is addressed (until C3 allows for CORS requests).